### PR TITLE
Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Configuration file for EditorConfig
+# More information is available under http://EditorConfig.org
+
+# Ignore any other files further up in the file system
+root = true
+
+# Configuration for all files
+[*]
+# Enforce Unix style line endings (\n only)
+end_of_line = lf
+# Always end files with a blank line
+insert_final_newline = true
+# Force space characters for indentation
+indent_style = space
+# Always indent by 2 characters
+indent_size = 2
+# Remove whitespace characters at the end of line
+trim_trailing_whitespace = true
+# Fix tab size to 8 in every editor
+tab_width = 8
+# Enconding
+charset = utf-8

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ obj-disp
 lib2
 .emacs*
 *.pyc
+cmake-build-debug
+.idea
+.DS_Store
 *~
 
 


### PR DESCRIPTION
Here are the changes:

- Added .editorconfig to address the inconsistencies among different editors. Now, every editor which supports Editorconfig will render the code correctly. I realized that the tabs used in the code should be interpreted as 8 spaces.
- Modified the .gitignore to support coding on Mac OS and CLion. 