### PR TITLE
removing unnecessary %(get_in) template variable

### DIFF
--- a/src/cnn_codegen.cc
+++ b/src/cnn_codegen.cc
@@ -180,20 +180,6 @@ namespace boda
 	insert_nda_ix_exprs( rcg->tsvs, "pel_ix_" + str(i), must_find(rcg->all_ix_dims,"out_pel_ix"),
 			     strprintf( "(%%(pel_tile)*%%(work_pels_dim)+%s)", str(i).c_str() ) );
       }
-      string const get_in = strprintf( 
-	"float v = 0;\n"
-	"      int const smem_in_ix_y = %%(out_pel_ix_y)*%%(stride_y_dim)+%%(filts_ix_out_chan_elem_y) - %%(in_pad_y_dim);\n"
-	"      int const smem_in_ix_x = %%(out_pel_ix_x)*%%(stride_x_dim)+%%(filts_ix_out_chan_elem_x) - %%(in_pad_x_dim);\n"
-	"      if(smem_in_ix_y >= 0 && smem_in_ix_x >= 0 && \n"
-	"          %%(out_pel_ix_img) < %%(in_img_dim) && \n"
-	"         smem_in_ix_x < %%(in_x_dim) && smem_in_ix_y < %%(in_y_dim) ) {\n"
-	"        v = in[%%(out_pel_ix_img)*%%(in_img_stride) +\n"
-	"          %%(filts_ix_out_chan_elem_in_chan)*%%(in_chan_stride) +\n"
-	"          smem_in_ix_y*%%(in_y_stride) +\n"
-	"          smem_in_ix_x*%%(in_x_stride)];\n" 
-	"      }"
-				       );
-      rcg->set( "get_in", get_in );
       for( uint32_t tx = 0; tx != work.dsz( "out_chan" ); ++tx ) {
 	rcg->line( "loads", strprintf( "filts_strip[%s] = filts_smem[%%(LOC_ID_1D_out_chan_tile)+%s*%%(work_out_chan_tile_dim)];",
 				       str(tx).c_str(), str(tx).c_str() ) );

--- a/test/rtc/conv.cucl
+++ b/test/rtc/conv.cucl
@@ -29,8 +29,12 @@ CUCL_GLOBAL_KERNEL void %(rtc_func_name)( GASQ float const * const filts, // CUC
     for( int32_t i = 0; i != %(pel_smem_load_iter); ++i ) {
       if( (LOC_ID_1D+LOC_SZ_1D*i) < blk_pel_ix_sz ) { 
 	int32_t const out_pel_ix = (blk_pel_ix_base+LOC_ID_1D+LOC_SZ_1D*i);
-	%(get_in);
-	in_smem[LOC_ID_1D+LOC_SZ_1D*i] = v;
+        
+        int const smem_in_ix_y = %(out_pel_ix_y) * %(stride_y_dim) + %(filts_ix_out_chan_elem_y) - %(in_pad_y_dim);
+        int const smem_in_ix_x = %(out_pel_ix_x) * %(stride_x_dim) + %(filts_ix_out_chan_elem_x) - %(in_pad_x_dim);
+        if(smem_in_ix_y >= 0 && smem_in_ix_x >= 0 && %(out_pel_ix_img) < %(in_img_dim) && smem_in_ix_x < %(in_x_dim) && smem_in_ix_y < %(in_y_dim) ) {
+          in_smem[LOC_ID_1D+LOC_SZ_1D*i] = in[%(out_pel_ix_img) * %(in_img_stride) + %(filts_ix_out_chan_elem_in_chan) * %(in_chan_stride) + smem_in_ix_y * %(in_y_stride) + smem_in_ix_x * %(in_x_stride)];
+  	}
       }
     }
     filts_off += %(filts_x_stride);


### PR DESCRIPTION
I created a new branch called "minor_refactoring" to inform you about some parts of the code which seem to be obsolete and unnecessary. I can find those snippets and try to fix them and push them to this branch and gradually we can merge them into the master, if you seem fit.
There might be a reason behind some of the code which I assumed to be unnecessary. In so, please let me know. Otherwise, keeping them like this will make the codebase complex and hard to follow in the future.